### PR TITLE
Fix for responses without parent board in cache

### DIFF
--- a/app/clients/messageResponsesClient.js
+++ b/app/clients/messageResponsesClient.js
@@ -24,12 +24,13 @@ module.exports = function(log, httpClient, cache, scrapers) {
 
         function getParentBoardId(threadId) {
             var boardList = cache.get("boardList");
-            return _.find(boardList, function(m,i) {
+            var parentBoard = _.find(boardList, function(m,i) {
                 log.debug("Getting: threadList/" + m.id + " in the search for threadId " + threadId);
                 var threadList = cache.get("threadList/"+m.id);
                 var index = _.findIndex(threadList, {'id': parseInt(threadId)});
                 return index > -1;
-            }).id;
+            });
+            return (parentBoard) ? (parentBoard.id) : -1
         }
 
 

--- a/app/clients/messageResponsesClient.js
+++ b/app/clients/messageResponsesClient.js
@@ -35,7 +35,7 @@ module.exports = function(log, httpClient, cache, scrapers) {
 
 
         function getParentThreadId(messageId) {
-            return messageId.split("/")[1];
+            return parseInt(messageId.split("/")[1]);
         }
 
         _.each(cachedMessageLists, function(cachedMessage,i) {


### PR DESCRIPTION
Instead of an internal server error all other responses with parent
boards in cache are still returned. Those respones which are missing
the parent board in cache have -1 set as the parent board id instead.